### PR TITLE
githubコマンドの使い方に見つけたtypo修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ### github plugin
 
-- `$gihub repos`: pyconjp organization のリポジトリ一覧を返す
+- `$github repos`: pyconjp organization のリポジトリ一覧を返す
 - `$github search keywords`: 指定されたキーワードにマッチするissueを返す
 - `$github code keywords`: 指定されたキーワードにマッチするコードを返す
 


### PR DESCRIPTION
## チケット

直接直したほうが早いので、チケットはありません

## レビューしてほしいところ

* ありません

## pyconjpbotの動作確認

ここからgihubはtypoと判断しました
https://pyconjp.slack.com/archives/C01FBPX83GD/p1651228993291309

- `$gihub repos`
  - >コマンド $gihub は登録されていません
- `$github repos`
  - >pyconjp のリポジトリ一覧
